### PR TITLE
Album art not working properly fix

### DIFF
--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -15,6 +15,7 @@ Item {
     property string track: ""
     property string artist: ""
     property string playerIcon: ""
+    property string albumArt: ""
 
     property bool noPlayer: true
     
@@ -67,6 +68,8 @@ Item {
 
             var track = metadata["xesam:title"];
             var artist = metadata["xesam:artist"];
+            var trackid = metadata["mpris:trackid"];
+            getThumbnailUrl(trackid);
 
             root.track = track ? track : "";
             root.artist = artist ? artist : "";
@@ -74,7 +77,7 @@ Item {
             // other metadata
             var k;
             for (k in metadata) {
-                //print(" -- " + k + " " + metadata[k]);
+                print(" -- " + k + " " + metadata[k]);
             }
         }
     }
@@ -101,6 +104,25 @@ Item {
         return service.startOperationCall(operation);
     }
 
+    function getThumbnailUrl(trackid) {
+        var xmlhttp = new XMLHttpRequest();
+        var url = "https://open.spotify.com/oembed?url="+trackid;
+
+        xmlhttp.onreadystatechange=function() {
+            if (xmlhttp.readyState == XMLHttpRequest.DONE && xmlhttp.status == 200) {
+                var obj = JSON.parse(xmlhttp.responseText);
+                setAlbumArt(obj.thumbnail_url);
+            }
+        }
+        xmlhttp.open("GET", url, true);
+        xmlhttp.send();
+    }
+
+    function setAlbumArt(albumArt) {
+        root.albumArt = albumArt;
+        print(albumArt);
+    }
+
     states: [
         State {
             name: "off"
@@ -108,7 +130,7 @@ Item {
         State {
             name: "playing"
         },
-        State {
+        State {xce
             name: "paused"
         }
     ]
@@ -118,7 +140,7 @@ Item {
             Layout.fillHeight: true
             Layout.fillWidth: true
             fillMode: Image.PreserveAspectFit
-            source: mpris2Source.data[mpris2Source.last].Metadata["mpris:artUrl"]
+            source: root.albumArt
         }
     }
 }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -34,13 +34,27 @@ Item {
         onSourceAdded: {
             //print("XXX source added: " + source);
             last = source;
+            if (source === last) {
+                last = "@multiplex"
+            }
         }
 
         onSourcesChanged: {
+            //print("Changed Source");
             updateData();
         }
 
         onDataChanged: {
+            //print("Data Changed");
+            for (var k = 0; k < 3; k++) {
+                var d = data[sources[k]];
+                if (d) {
+                    print(d+" "+d["PlaybackStatus"]);
+                    if (d["PlaybackStatus"] == "Playing") {
+                        last = sources[k];
+                    }
+                }
+            }
             updateData();
         }
 
@@ -69,16 +83,24 @@ Item {
             var track = metadata["xesam:title"];
             var artist = metadata["xesam:artist"];
             var trackid = metadata["mpris:trackid"];
-            getThumbnailUrl(trackid);
+            var artUrl = metadata["mpris:artUrl"];
+            if (artUrl) {
+                print(artUrl);
+                if (artUrl.toString().startsWith("file:///")) {
+                    root.albumArt = artUrl;
+                } else {
+                    getThumbnailUrl(trackid);
+                }
+            }
 
             root.track = track ? track : "";
             root.artist = artist ? artist : "";
 
             // other metadata
-            var k;
-            for (k in metadata) {
-                print(" -- " + k + " " + metadata[k]);
-            }
+            //var k;
+            //for (k in metadata) {
+            //    print(" -- " + k + " " + metadata[k]);
+            //}
         }
     }
     function play() {
@@ -120,7 +142,6 @@ Item {
 
     function setAlbumArt(albumArt) {
         root.albumArt = albumArt;
-        print(albumArt);
     }
 
     states: [
@@ -130,7 +151,7 @@ Item {
         State {
             name: "playing"
         },
-        State {xce
+        State {
             name: "paused"
         }
     ]

--- a/src/metadata.desktop
+++ b/src/metadata.desktop
@@ -51,7 +51,6 @@ Comment[zh_CN]=显示当前正在播放的专辑图片
 Icon=applications-system
 Type=Service
 X-KDE-ServiceTypes=Plasma/Applet
-X-KDE-Library=plasma_applet_albumart
 
 X-KDE-PluginInfo-Author=%{AUTHOR}
 X-KDE-PluginInfo-Email=%{EMAIL}


### PR DESCRIPTION
This widget wasn't working properly in my manjaro kde and after doing a quick search found that other people had the same issue.
I took a look and found two issues, one in the metadata.desktop file, apparently X-KDE-Library was preventing the widget from being attached to the desktop, and the other one in main.qml. The artUrl metadata wasn't pointing correctly to the album artwork. 
A quick google search helped me find a way to get a thumbnail url for the album artwork [https://stackoverflow.com/a/10126351](url).
