### PR TITLE
Fix for new versions of Spotify that contain the URL in mpris:artUrl

### DIFF
--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -86,7 +86,7 @@ Item {
             var artUrl = metadata["mpris:artUrl"];
             if (artUrl) {
                 print(artUrl);
-                if (artUrl.toString().startsWith("file:///")) {
+                if (artUrl.toString().startsWith("file:///") || artUrl.toString().startsWith("https://i.scdn.co/image/")) {
                     root.albumArt = artUrl;
                 } else {
                     getThumbnailUrl(trackid);


### PR DESCRIPTION
On my ArchLinux, on Spotify, the album cover is present in `metadata["mpris:artUrl"]`. So this PR adds a condition to check if this tag contains a cover URL hosted on the Spotify CDN.